### PR TITLE
[#92] stdlib strings.Replace was added to template's functions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -252,6 +252,8 @@ out:
 | `slice`           |                              |                                                                                                                                                                                   |
 | `slice.New`       |       N `any` elements       | Create new slice from any numbers of elements <br/>(`{ $element := slice.New "a" 1 "b" }}`)                                                                                       |
 | `slice.Append`    | slice,<br/> N `any` elements | Add element to exists slice <br/>(`{{ $element := slice.Append $element "b"}}`)                                                                                                   |
+| `strings`         |                              |                                                                                                                                                                                   |
+| `strings.Replace` |  s, old, new string, n int   | Replace returns a copy of the string `s` with `old` replaced by `new` (work the same as `strings.Replace` from `stdlib`).                                                         |
 
 Custom template's functions added as custom arguments to the template
 [function map](https://pkg.go.dev/text/template#hdr-Functions).

--- a/internal/entity/slice.go
+++ b/internal/entity/slice.go
@@ -1,11 +1,11 @@
 package entity
 
-type SLiceFn struct{}
+type SliceFn struct{}
 
-func (sfn SLiceFn) New(elems ...any) []any {
+func (sfn SliceFn) New(elems ...any) []any {
 	return elems
 }
 
-func (sfn SLiceFn) Append(s []any, elems ...any) []any {
+func (sfn SliceFn) Append(s []any, elems ...any) []any {
 	return append(s, elems...)
 }

--- a/internal/entity/strings.go
+++ b/internal/entity/strings.go
@@ -1,0 +1,9 @@
+package entity
+
+import "strings"
+
+type StringsFn struct{}
+
+func (sfn StringsFn) Replace(input, from, to string, n int) string {
+	return strings.Replace(input, from, to, n)
+}

--- a/internal/entity/template.go
+++ b/internal/entity/template.go
@@ -9,8 +9,9 @@ import (
 
 var (
 	TemplateFnsMap = map[string]any{
-		"random": func() any { return RandomFn{} },
-		"slice":  func() any { return SLiceFn{} },
+		"random":  func() any { return RandomFn{} },
+		"slice":   func() any { return SliceFn{} },
+		"strings": func() any { return StringsFn{} },
 	}
 )
 

--- a/internal/entity/template_test.go
+++ b/internal/entity/template_test.go
@@ -41,9 +41,29 @@ func Test_TemplateProc(t *testing.T) {
 	})
 }
 
-func Test_TemplateFnsMap(t *testing.T) {
-	t.Run("slice_func", func(t *testing.T) {
-		t.Run("new", func(t *testing.T) {
+func Test_TemplateFunctions_slice(t *testing.T) {
+	t.Run("entity", func(t *testing.T) {
+		const (
+			elem1 = "1"
+			elem2 = "2"
+			elem3 = "3"
+		)
+
+		var (
+			fn = SliceFn{}
+		)
+
+		t.Run("slice.New", func(t *testing.T) {
+			slice := fn.New([]any{elem1, elem2, elem3}...)
+			assert.Equal(t, []any{elem1, elem2, elem3}, slice)
+		})
+		t.Run("slice.Append", func(t *testing.T) {
+			slice := fn.Append([]any{elem1, elem2}, elem3)
+			assert.Equal(t, []any{elem1, elem2, elem3}, slice)
+		})
+	})
+	t.Run("template_slice", func(t *testing.T) {
+		t.Run("slice.New", func(t *testing.T) {
 			t.Run("var", func(t *testing.T) {
 				const (
 					in = `{{ $element := slice.New "a" 1 "b" }}{{ $element }}`
@@ -88,7 +108,7 @@ cmd:
 				assert.Equal(t, exp, res)
 			})
 		})
-		t.Run("append", func(t *testing.T) {
+		t.Run("slice.Append", func(t *testing.T) {
 			t.Run("single", func(t *testing.T) {
 				const (
 					in = `{{ $element := slice.New "a" }}{{ $element := slice.Append $element "b"}}{{ $element }}`
@@ -109,5 +129,32 @@ cmd:
 
 			})
 		})
+	})
+}
+
+func Test_TemplateFunctions_strings(t *testing.T) {
+	var (
+		fn = StringsFn{}
+	)
+
+	t.Run("entity", func(t *testing.T) {
+		t.Run("strings.Replace", func(t *testing.T) {
+			const (
+				in  = "some_value"
+				exp = "some value"
+			)
+			result := fn.Replace(in, "_", " ", -1)
+			assert.Equal(t, exp, result)
+
+		})
+	})
+	t.Run("template_strings", func(t *testing.T) {
+		const (
+			in = `{{ strings.Replace "some_value" "_" " " -1 }}`
+		)
+		proc := TmplProc{templateFns: TemplateFnsMap}
+		res, err := proc.Process(tmplName, in)
+		assert.NoError(t, err)
+		assert.Equal(t, "some value", res)
 	})
 }


### PR DESCRIPTION
### Description
New function to templates added: `strings.Replace` (from `stdlib`):
```
const (
	in = `{{ strings.Replace "some_value" "_" " " -1 }}`
)
proc := TmplProc{templateFns: TemplateFnsMap}
res, err := proc.Process(tmplName, in)
assert.NoError(t, err)
assert.Equal(t, "some value", res)
```
(test -> internal/entity/template_test.go:151)

Closes #92