### PR TITLE
[#94] replace the release notes (.goreleaser.yml)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,3 +40,6 @@ changelog:
       - Merge pull request
       - Merge remote-tracking branch
       - Merge branch
+
+release:
+  mode: replace


### PR DESCRIPTION
### Description
Set replace the existing release notes for `goreleaser`

Closes #94